### PR TITLE
TECH-471. Fix link to 404 in the Auth docs

### DIFF
--- a/pages/authentication.mdx
+++ b/pages/authentication.mdx
@@ -22,7 +22,7 @@ In the following walkthrough, we will:
 
 :::success Example Code
 
-We have provided example code for generating App Credentials in the [App Authentication](/tutorial/app-authentication)
+We have provided example code for generating App Credentials in the [App Authentication](/tutorial/manual-app-authentication)
 tutorial.
 
 :::
@@ -96,7 +96,7 @@ without transmitting your password (or `client_secret`).
 This is done by minting a new JSON Web Token or JWT using the `client_id` and securely
 signing it with the `client_secret`.
 This is a somewhat complex process to do manually, but we have provided example code in the
-[App Authentication](/tutorial/app-authentication) tutorial.
+[App Authentication](/tutorial/manual-app-authentication) tutorial.
 
 ...generate token using client_id and client_secret...
 


### PR DESCRIPTION
We wanted to point users to a tutorial, but this was a 404. This appears to have happened when the Argo workflow renamed the file: https://github.com/climateengine/spfi-docs-public/commit/7ce1353f3f6f7cbfee3588a597436efdeae238ab

This commit corrects the link.