### PR TITLE
Add missing "s" to Auth tutorial

### DIFF
--- a/pages/authentication.mdx
+++ b/pages/authentication.mdx
@@ -22,7 +22,7 @@ In the following walkthrough, we will:
 
 :::success Example Code
 
-We have provided example code for generating App Credentials in the [App Authentication](/tutorial/manual-app-authentication)
+We have provided example code for generating App Credentials in the [App Authentication](/tutorials/manual-app-authentication)
 tutorial.
 
 :::
@@ -96,7 +96,7 @@ without transmitting your password (or `client_secret`).
 This is done by minting a new JSON Web Token or JWT using the `client_id` and securely
 signing it with the `client_secret`.
 This is a somewhat complex process to do manually, but we have provided example code in the
-[App Authentication](/tutorial/manual-app-authentication) tutorial.
+[App Authentication](/tutorials/manual-app-authentication) tutorial.
 
 ...generate token using client_id and client_secret...
 


### PR DESCRIPTION
In
https://github.com/climateengine/spfi-docs-public/commit/bc9f1576a87f65994acccaf5fd5ac71e48627c6d we updated this but we missed the lack of "s" in the link which would also cause the 404s to happen.

This commit adds the missing "s".