### PR TITLE
TECH-509. Fix dead link at the end of quick start page.

### DIFF
--- a/pages/quickstart.mdx
+++ b/pages/quickstart.mdx
@@ -77,5 +77,5 @@ If you see a response with item information, congratulations! You've successfull
 
 ---
 
-Next, follow along with the [Jupyter Notebook tutorials](/tutorials/) to learn how enrich your own data with SpatiaFi
+Next, follow along with the [Jupyter Notebook tutorials](/tutorials/manual-app-authentication/) to learn how enrich your own data with SpatiaFi
 climate data, or check out the [API Reference](/api/) to learn more about the SpatiaFi API.


### PR DESCRIPTION
Here we were link to `/tutorials` as a page, but we don't actually have an index page for the tutorials leading the user to a 404.

This commit instead links the user to the first tutorial.