### PR TITLE
TECH-534. Fix broken links within the tutorials.

### DIFF
--- a/index.md
+++ b/index.md
@@ -50,7 +50,7 @@ For Python, we recommend the library [Authlib](https://docs.authlib.org/en/lates
 
 🔑 **Using the API requires authentication. Test credentials can be obtained by [contacting us](https://spatiafi.com/contact/).**
 
-See the [Authentication tutorial](/tutorials/authentication) for more information, and examples in Python.
+See the [Authentication tutorial](/tutorials/3-manual-app-authentication) for more information, and examples in Python.
 
 ### Request Format
 

--- a/notebooks/1-tutorial-intro.ipynb
+++ b/notebooks/1-tutorial-intro.ipynb
@@ -19,7 +19,7 @@
     "App Credentials, store them locally on your computer, and use them to authenticate to the API.\n",
     "\n",
     "If you would like to avoid using the SpatiaFi Python Library (advanced usage), you can use the [Authlib](https://docs.authlib.org/en/latest/index.html) library.\n",
-    "See [Manual App Authentication](https://docs.spatiafi.com/tutorials/manual-app-authentication/) for an example."
+    "See [Manual App Authentication](https://docs.spatiafi.com/tutorials/3-manual-app-authentication/) for an example."
    ]
   },
   {

--- a/notebooks/2-save-images.ipynb
+++ b/notebooks/2-save-images.ipynb
@@ -51,7 +51,7 @@
     "\n",
     "We load previously generated App Credentials.\n",
     "\n",
-    "**If you have not generated App Credentials, please do so first by running the [App Authentication](https://docs.spatiafi.com/tutorials/app-authentication/) notebook**"
+    "**If you have not generated App Credentials, please do so first by running the [App Authentication](https://docs.spatiafi.com/tutorials/3-manual-app-authentication/) notebook**"
    ]
   },
   {


### PR DESCRIPTION
When we rename notebooks it also causes references to become deadlinks. Ideally we'll be able to proactively catch this in the future, but for next in this commit we just fix the occurrences of broken links. I found these by grepping for `/tutorials/` and then checking each occurrence (there aren't that many of them).