### PR TITLE
TECH-559. Verify that the notebooks can build when opening a PR

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,10 +60,10 @@ Because of this, notebooks must follow a few strict guidelines:
 The notebooks must be able to run in a minimal Jupyter environment such as
 [Google Colab](https://colab.research.google.com/)
 or [Binder](https://mybinder.org/) without assuming that any additional Python packages are installed.
-**Many geospaital Python packages such as GDAL, Cartopy, etc. are not pre-installed in these environments.**
+**Many geospatial Python packages such as GDAL, Cartopy, etc. are not pre-installed in these environments.**
 
-To work around this, Python packages (and Ubuntu `apt` packages) used in the notebooks must be installed
-in the notebook itself.
+To work around this, Python packages (and Ubuntu `apt` packages) used in the
+notebooks must be installed in the notebook itself.
 
 ##### Installing Python Packages
 

--- a/workflows/README.md
+++ b/workflows/README.md
@@ -6,7 +6,7 @@ is used to automatically trigger builds when new commits are pushed to the repos
 - [spfi-docs-public-wf.yaml](spfi-docs-public-wf.yaml) - This is the `Workflow` definition.  Here you can define the steps to build. In its simplest form, it can call an existing `WorkflowTemplate`  (more on this later).
 - [repo-sensor.yaml](repo-sensor.yaml) - This defines the "Sensor" which will trigger the [spfi-docs-public-wf.yaml](spfi-docs-public-wf.yaml) `Workflow` when a new commit is pushed to the repository.
 - [kustomization.yaml](kustomization.yaml) - This is the `Kustomization` definition.  It helps deploy the `Workflow` and `Sensor` to the cluster.
-- [deploy-sensor.sh](delpoy-sensor.sh) - This is a helper script to deploy the `Workflow` and `Sensor` to the cluster.
+- [deploy-sensor.sh](deploy-sensor.sh) - This is a helper script to deploy the `Workflow` and `Sensor` to the cluster.
 - [submit-wf.sh](submit-wf.sh) - This is a helper script to submit the `Workflow` to the cluster. This can be run at any time to manually trigger a build.
 
 ## Workflow Templates

--- a/workflows/README.md
+++ b/workflows/README.md
@@ -12,7 +12,7 @@ is used to automatically trigger builds when new commits are pushed to the repos
 ## Workflow Templates
 
 There are a number of predefined `WorkflowTemplate`s. These are shared across
-all projects. These workflows are defined in a internal private repo.
+all projects. These workflows are defined in an internal private repo.
 
 This workflow runs a subset of what we run when building the docs when a PR is
 published against this repo.

--- a/workflows/README.md
+++ b/workflows/README.md
@@ -1,0 +1,22 @@
+# Docs Builder
+
+Building is done by [Argo Workflows](https://argoproj.github.io/argo-workflows/) and [Argo Events](https://argoproj.github.io/argo-events/)
+is used to automatically trigger builds when new commits are pushed to the repository.
+
+- [spfi-docs-public-wf.yaml](spfi-docs-public-wf.yaml) - This is the `Workflow` definition.  Here you can define the steps to build. In its simplest form, it can call an existing `WorkflowTemplate`  (more on this later).
+- [repo-sensor.yaml](repo-sensor.yaml) - This defines the "Sensor" which will trigger the [spfi-docs-public-wf.yaml](spfi-docs-public-wf.yaml) `Workflow` when a new commit is pushed to the repository.
+- [kustomization.yaml](kustomization.yaml) - This is the `Kustomization` definition.  It helps deploy the `Workflow` and `Sensor` to the cluster.
+- [deploy-sensor.sh](delpoy-sensor.sh) - This is a helper script to deploy the `Workflow` and `Sensor` to the cluster.
+- [submit-wf.sh](submit-wf.sh) - This is a helper script to submit the `Workflow` to the cluster. This can be run at any time to manually trigger a build.
+
+## Workflow Templates
+
+There are a number of predefined `WorkflowTemplate`s. These are shared across
+all projects. These workflows are defined in a internal private repo.
+
+This workflow runs a subset of what we run when building the docs when a PR is
+published against this repo.
+
+We acknowledge that contributors may have a limited view of these builds. If
+this causes a problem for you please feel free to contact the maintainers of
+this project and we'll be happy to help.

--- a/workflows/deploy-sensor.sh
+++ b/workflows/deploy-sensor.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+set -eux -o pipefail
+
+# This script is used to deploy the `Sensor` and the `Workflow` (casting it as a `ConfigMap`) to the cluster.
+# To run this, you will need to have the following installed:
+# - kubectl
+# - kustomize
+
+# If kubectl context gke_ce-builder_us-central1_ce-builder does not exist, create it
+if ! kubectl config get-contexts gke_ce-builder_us-central1_ce-builder &> /dev/null; then
+    gcloud container clusters get-credentials ce-builder --region us-central1 --project ce-builder
+fi
+
+# Set the kubectl context to gke_ce-builder_us-central1_ce-builder
+kubectl config use-context gke_ce-builder_us-central1_ce-builder
+
+# Deploy to the cluster
+kustomize build . | kubectl apply -f -

--- a/workflows/kustomization.yaml
+++ b/workflows/kustomization.yaml
@@ -1,0 +1,14 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: argo
+
+resources:
+  - repo-PR-sensor.yaml
+
+configMapGenerator:
+  - name: spfi-docs-public-wf
+    files:
+      - spfi-docs-public-wf.yaml
+    options:
+      disableNameSuffixHash: true

--- a/workflows/repo-PR-sensor.yaml
+++ b/workflows/repo-PR-sensor.yaml
@@ -1,0 +1,61 @@
+# This sensor monitors the `spfi-docs-public` for pull requests and triggers an
+# Argo workflow to ensure that the docs build.
+
+apiVersion: argoproj.io/v1alpha1
+kind: Sensor
+metadata:
+  name: spfi-docs-public-PR-build # This should be unique across all Sensors.
+  namespace: argo
+spec:
+  template:
+    serviceAccountName: operate-workflow-sa
+  dependencies:
+    - name: github
+      eventSourceName: github
+      eventName: github-climateengine
+      filters:
+        data:
+          # Type of Github event that triggered the delivery: [pull_request, push, issues, label, ...]
+          # https://docs.github.com/en/developers/webhooks-and-events/webhook-events-and-payloads
+          - path: headers.X-Github-Event
+            type: string
+            value:
+              - pull_request
+          # Filter on the repository name (e.g. "climateengine/spfi-docs-public")
+          - path: body.repository.full_name
+            type: string
+            value:
+              - climateengine/spfi-docs-public
+          # Docs for the different actions can be found here: https://docs.github.com/en/webhooks-and-events/webhooks/webhook-events-and-payloads?actionType=edited#pull_request
+          - path: body.action
+            type: string
+            value:
+              - opened
+              - edited
+              - reopened
+              - synchronize
+          # We only want to rerun on open PRs
+          - path: body.pull_request.state
+            type: string
+            value:
+              - open
+          # We only want to run against PRs that target main
+          - path: body.pull_request.base.ref
+            type: string
+            value: [main]
+
+  triggers:
+    - template:
+        name: spfi-docs-public
+        argoWorkflow:
+          operation: submit
+          source:
+            configmap:
+              name: spfi-docs-public-wf
+              key: spfi-docs-public-wf.yaml
+          parameters:
+            # Send the SHA of the commit to the Workflow.
+            - src:
+                dependencyName: github
+                dataKey: body.after # The SHA of the commit.
+              dest: spec.arguments.parameters.1.value

--- a/workflows/spfi-docs-public-wf.yaml
+++ b/workflows/spfi-docs-public-wf.yaml
@@ -1,0 +1,194 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: spfi-docs-public-
+  namespace: argo
+spec:
+  serviceAccountName: argo-workflow
+  arguments:
+    parameters:
+      - name: repo-name
+        value: climateengine/spfi-docs-public
+      - name: commit-sha
+        value: ""
+  hooks:
+    exit:
+      templateRef:
+        name: github-templates
+        template: update-status
+      arguments:
+        parameters:
+          - name: repo-name
+            value: "{{workflow.parameters.repo-name}}"
+          - name: commit-sha
+            value: "{{workflow.parameters.commit-sha}}"
+          - name: status
+            value: "completed"
+          - name: conclusion
+            value: "{{workflow.status}}"
+          - name: failures
+            value: "{{workflow.failures}}"
+          - name: run-id
+            value: "{{=workflow.outputs.parameters['run-id'] != nil ? workflow.outputs.parameters['run-id'] : ''}}"
+  entrypoint: main
+  templates:
+    - name: main
+      dag:
+        tasks:
+          - name: github-status-in-progress
+            templateRef:
+              name: github-templates
+              template: update-status
+            arguments:
+              parameters:
+                - name: repo-name
+                  value: "{{workflow.parameters.repo-name}}"
+                - name: status
+                  value: "in_progress"
+                - name: commit-sha
+                  value: "{{workflow.parameters.commit-sha}}"
+          - name: checkout-spfi-docs-public
+            templateRef:
+              name: github-templates
+              template: clone
+            arguments:
+              parameters:
+                - name: repo-name
+                  value: climateengine/spfi-docs-public
+                - name: commit-sha
+                  value: "{{workflow.parameters.commit-sha}}"
+          - name: checkout-spfi-docs-build
+            templateRef:
+              name: github-templates
+              template: clone
+            arguments:
+              parameters:
+                - name: repo-name
+                  value: climateengine/spfi-docs-build
+                - name: branch
+                  value: main
+          - name: run-pre-commit-with-cache
+            templateRef:
+              name: run-pre-commit
+              template: run-pre-commit-with-cache
+            arguments:
+              artifacts:
+                - name: src
+                  from: "{{tasks.checkout-spfi-docs-public.outputs.artifacts.src}}"
+            dependencies:
+              - checkout-spfi-docs-public
+          - name: ls-notebooks
+            template: ls-notebooks
+            arguments:
+              artifacts:
+                - name: src
+                  from: "{{tasks.checkout-spfi-docs-public.outputs.artifacts.src}}"
+            dependencies:
+              - checkout-spfi-docs-public
+
+          # Run nbmake on each notebook from ls-notebooks
+          # This makes sure that the notebooks successfully run, and produce the expected output.
+          - name: nbmake-notebooks
+            template: nbmake-notebook
+            arguments:
+              parameters:
+                - name: notebook-filename
+                  value: "{{item}}"
+              artifacts:
+                - name: src
+                  from: "{{tasks.checkout-spfi-docs-public.outputs.artifacts.src}}"
+            withParam: "{{tasks.ls-notebooks.outputs.result}}"
+            dependencies:
+              - ls-notebooks
+
+    - name: ls-notebooks
+      script:
+        image: python:3.10
+        command: [python]
+        source: |
+          # List all .ipynb files in /src/notebooks
+          import os
+          import glob
+          import json
+
+          notebooks = glob.glob(os.path.join('src', 'notebooks', '*.ipynb'))
+          notebooks = [os.path.basename(notebook) for notebook in notebooks]
+          print(json.dumps(notebooks))
+      inputs:
+        artifacts:
+          - name: src
+            path: /src
+
+    - name: generate-tutorial-links
+      script:
+        image: bash
+        command: [bash]
+        source: |
+          set -eux -o pipefail
+
+          # Delete and recreate /src/tutorials
+          rm -rf /src/tutorials
+          mkdir -p /src/tutorials
+
+          # For every *.ipynb notebook in /src/notebooks, create a markdown file in /src/tutorials with a link to the notebook
+          for notebook in /src/notebooks/*.ipynb; do
+              notebook_name=$(basename $notebook)
+              notebook_name=${notebook_name%.*}
+              cat << EOF > /src/tutorials/${notebook_name}.md
+          # Automatically Generated!
+
+          This tutorial was automatically generated from a Jupyter notebook.
+          To view/edit the tutorial, see the notebook [${notebook_name}.ipynb](../notebooks/${notebook_name}.ipynb).
+
+          EOF
+          done
+      inputs:
+        artifacts:
+          - name: src
+            path: /src
+      outputs:
+        artifacts:
+          - name: src
+            path: /src
+
+    - name: nbmake-notebook
+      script:
+        image: jupyter/scipy-notebook
+        securityContext:
+          runAsUser: 0
+        command: [bash]
+        source: |
+          set -eux
+          sudo apt update
+          pip install papermill nbmake
+          # Run the notebook once with papermill to run "magic" commands. nbmake doesn't support these.
+          papermill --log-output "/src/notebooks/{{inputs.parameters.notebook-filename}}"
+          pytest -p no:cacheprovider --nbmake --overwrite "/src/notebooks/{{inputs.parameters.notebook-filename}}"
+        env:
+          - name: GRANT_SUDO
+            value: "yes"
+          - name: PYDEVD_DISABLE_FILE_VALIDATION
+            value: "1"
+          - name: NO_COLOR
+            value: "1"
+          - name: TERM
+            value: "xterm"
+          - name: SPATIAFI_CLIENT_ID
+            value: "1a48aaa9-0972-476e-a068-c1c83a857103"
+          - name: SPATIAFI_CLIENT_SECRET
+            value: "FiEwzLsOvBvnJN69zPDDkTxotyiAgamaJkVoH9i5mvw"
+      inputs:
+        artifacts:
+          - name: src
+            path: /src
+        parameters:
+          - name: notebook-filename
+      outputs:
+        artifacts:
+          - name: notebook
+            path: "/src/notebooks/{{inputs.parameters.notebook-filename}}"
+            archive:
+              none: {}
+            gcs:
+              bucket: ce-builder-artifacts
+              key: "{{workflow.name}}/notebooks/{{inputs.parameters.notebook-filename}}"

--- a/workflows/submit-wf.sh
+++ b/workflows/submit-wf.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+set -eux -o pipefail
+
+# If kubectl context gke_ce-builder_us-central1_ce-builder does not exist, create it
+if ! kubectl config get-contexts gke_ce-builder_us-central1_ce-builder &> /dev/null; then
+    gcloud container clusters get-credentials ce-builder --region us-central1 --project ce-builder
+fi
+
+# Set the kubectl context to gke_ce-builder_us-central1_ce-builder
+kubectl config use-context gke_ce-builder_us-central1_ce-builder
+
+# Ensure Argo CLI is installed locally
+if ! command -v argo &> /dev/null; then
+    echo "Please install Argo CLI locally."
+    echo "See https://argoproj.github.io/argo-workflows/cli/ for more information."
+    echo "or https://github.com/argoproj/argo-workflows/releases for the latest release."
+    exit 1
+fi
+
+argo submit -n argo --log spfi-docs-build-wf.yaml


### PR DESCRIPTION
We would like to see feedback on changes to this repo's notebooks. Currently if a change to this repo "breaks" the building of the docs we won't find out until after merging. This is a longer feedback cycle than we desire.

This commit introduces an argo workflow that is similar to the workflow we use for building and publishing the docs, except we stop short of publishing the docs.