### PR TITLE
TECH-595. Fix incorrect id in tutorial.

### DIFF
--- a/notebooks/2-tutorial-points.ipynb
+++ b/notebooks/2-tutorial-points.ipynb
@@ -119,7 +119,7 @@
     "        + asset_coords[i][1]\n",
     "    )\n",
     "\n",
-    "    query = {\"item_id\": \"wildfire-risk-static-global-v1.0\", \"bidx\": \"1\"}\n",
+    "    query = {\"item_id\": \"ce-wildfire-risk-static-global-v1.0\", \"bidx\": \"1\"}\n",
     "\n",
     "    response = session.get(url, params=query)\n",
     "\n",


### PR DESCRIPTION
We were seeing this ID 404 when running this tutorial in CI: https://github.com/climateengine/spfi-docs-build/pull/6#issuecomment-1688864927 We then also had a customer reach out and report that the id was 404ing for them.