### PR TITLE
TECH-573 Remove trailing cells in notebooks

### DIFF
--- a/notebooks/2-save-images.ipynb
+++ b/notebooks/2-save-images.ipynb
@@ -171,14 +171,6 @@
     "    for chunk in response.iter_content(1024):\n",
     "        f.write(chunk)"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "b53e3a0c-7733-421d-ad21-fd9f0f63e8b3",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/notebooks/2-tutorial-lines.ipynb
+++ b/notebooks/2-tutorial-lines.ipynb
@@ -229,14 +229,6 @@
    "source": [
     "We can see that some locations near the line are at significant risk of fire. This can help inform where fire mitigation should take place."
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "89a3df3e-4290-4143-a273-769ea69d0546",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/notebooks/2-tutorial-points.ipynb
+++ b/notebooks/2-tutorial-points.ipynb
@@ -277,14 +277,6 @@
     "plt.tight_layout()\n",
     "plt.show()"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "3a7a98ac-a3a2-4f21-93de-b76e803e1edd",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/notebooks/2-tutorial-polygons.ipynb
+++ b/notebooks/2-tutorial-polygons.ipynb
@@ -289,14 +289,6 @@
    "source": [
     "So the mean probability of extreme heat in Northern Saudi Arabia is expected to triple by the end of century in SSP5-8.5."
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "36067796-53ae-4717-a738-9a11c50fcc94",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
These trailing cells show up in the output docs.

This commit removes them. Really I am removing them because I am testing changes to the docs building process and I would like to see things happen.

## Screenshots

### Before

<img width="992" alt="Screenshot 2023-09-01 at 10 10 16" src="https://github.com/climateengine/spfi-docs-public/assets/607279/4cdededb-b368-4f90-85de-75d5b3c9e339">
<img width="935" alt="Screenshot 2023-09-01 at 10 10 25" src="https://github.com/climateengine/spfi-docs-public/assets/607279/5db7a799-8382-4f02-bf6e-508dbb3d67aa">


### After

