### PR TITLE
TECH-797. Add paragraph about password prompt to auth docs

### DIFF
--- a/notebooks/1-tutorial-intro.ipynb
+++ b/notebooks/1-tutorial-intro.ipynb
@@ -18,6 +18,8 @@
     "In these tutorials we will use the open source [SpatiaFi Python Library](https://github.com/climateengine/py-spatiafi) which will create\n",
     "App Credentials, store them locally on your computer, and use them to authenticate to the API.\n",
     "\n",
+    "The first time you create a `session` object the client will prompt you for the username and password. Subsequent calls to `spatiafi.get_session()` will not need you to manually enter anything (the library makes use of a file it creates on your local filesystem to allow you to not have to do this manual step everytime). \n",
+    "\n",
     "If you would like to avoid using the SpatiaFi Python Library (advanced usage), you can use the [Authlib](https://docs.authlib.org/en/latest/index.html) library.\n",
     "See [Manual App Authentication](https://docs.spatiafi.com/tutorials/3-manual-app-authentication/) for an example."
    ]
@@ -111,7 +113,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.6"
+   "version": "3.10.12"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
We were talking with a user who was (reasonably) confused about where to enter the username and password that we give them. This commit adds a paragraph which add a little more detail about the behaviour of the py-spatiafi package.

Note that we do mention the file for credentials in the paragraph above, but we don't mention prompting for password.